### PR TITLE
feat: split barrier field into alliance and opponent barrier fields

### DIFF
--- a/data/match_schedule.txt
+++ b/data/match_schedule.txt
@@ -1,15 +1,15 @@
 Create schedule for 4 teams playing 3 rounds in 3 matches
 with a minimum match separation of 1 running 100000 iterations.
 
-   0:00   100.00% complete (1 updates), operation complete         balancing station appearances (Sykes method) used 0.000002 seconds.
+   0:00   100.00% complete (2 updates), operation complete         balancing station appearances (Sykes method) used 0.000005 seconds.
 
 Results for 4 teams playing 3 rounds in 3 matches
 
 Match Schedule
 --------------
-  1:    3     2     1     4 
-  2:    4     3     2     1 
-  3:    1     3     4     2 
+  1:    1     2     4     3 
+  2:    2     4     3     1 
+  3:    3     2     4     1 
 
 Schedule Statistics
 -------------------
@@ -29,9 +29,9 @@ Schedule Statistics
 
  team   #   d    part    opp    both    r/b <->   s1 s2 4+ repeats
  ----  --  --   -----   -----   -----   --- ---   -- -- ------------
-    1:  3   1 |  3  1 |  3  2 |  3  3 |  1b   1 |  2  1
-    2:  3   1 |  3  1 |  3  2 |  3  3 |  1b   1 |  1  2
-    3:  3   1 |  3  1 |  3  2 |  3  3 |  3r   0 |  1  2
+    1:  3   1 |  3  1 |  3  2 |  3  3 |  1b   1 |  1  2
+    2:  3   1 |  3  1 |  3  2 |  3  3 |  3r   0 |  1  2
+    3:  3   1 |  3  1 |  3  2 |  3  3 |  1b   1 |  2  1
     4:  3   1 |  3  1 |  3  2 |  3  3 |  1b   2 |  2  1
 ------------------------------------------------------------
  best:  3   1 |  3  1 |  3  2 |  3  3 |  1    0 |  2  2
@@ -48,5 +48,5 @@ alliance swap count histogram:
 1: 2
 0: 1
 
-elapsed time: 0.076643 seconds
+elapsed time: 0.076236 seconds
 

--- a/src/main/java/org/thingai/app/fanroc/FanrocScore.java
+++ b/src/main/java/org/thingai/app/fanroc/FanrocScore.java
@@ -11,7 +11,8 @@ public class FanrocScore extends Score implements IScoreConfig {
     // New scoring system fields
     private int whiteBallsScored; // 1 point each via human player
     private int goldenBallsScored; // 3 points each via robot autonomous
-    private int barriersPushed; // 0-2, 10 points each
+    private boolean allianceBarrierPushed; // true if alliance pushed their own barrier (10 points, no coefficient penalty)
+    private boolean opponentBarrierPushed; // true if alliance pushed opponent's barrier (10 bonus points)
     private int imbalanceCategory; // 0=balanced(2.0), 1=medium(1.5), 2=large(1.3)
     private int partialParking; // number of robots partially in green zone (5 points each)
     private int fullParking; // number of robots fully in green zone (10 points each)
@@ -32,8 +33,8 @@ public class FanrocScore extends Score implements IScoreConfig {
             default -> 1.3;
         };
 
-        // Subtract 0.2 if alliance didn't push their barrier (assuming 1 barrier per alliance)
-        if (barriersPushed == 0) {
+        // Subtract 0.2 if alliance didn't push their barrier
+        if (!allianceBarrierPushed) {
             baseCoeff -= 0.2;
         }
 
@@ -53,8 +54,8 @@ public class FanrocScore extends Score implements IScoreConfig {
         // Biological points = robot-scored balls + human-scored balls
         int biologicalPoints = (goldenBallsScored * 3) + whiteBallsScored;
 
-        // Barrier points
-        int barrierPoints = barriersPushed * 10;
+        // Barrier points: 10 points for each barrier pushed
+        int barrierPoints = (allianceBarrierPushed ? 10 : 0) + (opponentBarrierPushed ? 10 : 0);
 
         // End game points
         int endGamePoints = (partialParking * 5) + (fullParking * 10);
@@ -86,7 +87,8 @@ public class FanrocScore extends Score implements IScoreConfig {
         // New fields
         this.whiteBallsScored = temp.whiteBallsScored;
         this.goldenBallsScored = temp.goldenBallsScored;
-        this.barriersPushed = temp.barriersPushed;
+        this.allianceBarrierPushed = temp.allianceBarrierPushed;
+        this.opponentBarrierPushed = temp.opponentBarrierPushed;
         this.imbalanceCategory = temp.imbalanceCategory;
         this.partialParking = temp.partialParking;
         this.fullParking = temp.fullParking;
@@ -111,7 +113,8 @@ public class FanrocScore extends Score implements IScoreConfig {
 
         definitions.put("whiteBallsScored", new ScoreDefine("White Balls Scored by Human", null, null));
         definitions.put("goldenBallsScored", new ScoreDefine("Golden Balls Scored by Robot", null, null));
-        definitions.put("barriersPushed", new ScoreDefine("Barriers Pushed Away", null, null));
+        definitions.put("allianceBarrierPushed", new ScoreDefine("Alliance Barrier Pushed", null, null));
+        definitions.put("opponentBarrierPushed", new ScoreDefine("Opponent Barrier Pushed", null, null));
         definitions.put("imbalanceCategory", new ScoreDefine("Ball Imbalance Category (0=Balanced, 1=Medium, 2=Large)", null, null));
         definitions.put("partialParking", new ScoreDefine("Robots Partially in Green Zone", null, null));
         definitions.put("fullParking", new ScoreDefine("Robots Fully in Green Zone", null, null));

--- a/webui/src/app/core/models/score.model.ts
+++ b/webui/src/app/core/models/score.model.ts
@@ -8,7 +8,8 @@ export interface Score {
   // Fanroc scoring system fields (from JSON)
   whiteBallsScored?: number;
   goldenBallsScored?: number;
-  barriersPushed?: number;
+  allianceBarrierPushed?: boolean;
+  opponentBarrierPushed?: boolean;
   imbalanceCategory?: number;
   partialParking?: number;
   fullParking?: number;
@@ -53,9 +54,9 @@ export class FanrocScoringCalculator {
   /**
    * Get the balancing coefficient based on imbalance category
    * @param imbalanceCategory - The imbalance category (0=balanced, 1=medium, 2=large)
-   * @param barriersPushed - 1 if barrier was pushed, 0 if not (reduces coefficient by 0.2 if 0)
+   * @param allianceBarrierPushed - true if alliance pushed their barrier, false if not (reduces coefficient by 0.2 if false)
    */
-  static getBalancingCoefficient(imbalanceCategory: number, barriersPushed: number = 0): number {
+  static getBalancingCoefficient(imbalanceCategory: number, allianceBarrierPushed: boolean = false): number {
     let baseCoeff: number;
     switch (imbalanceCategory) {
       case 0:
@@ -73,7 +74,7 @@ export class FanrocScoringCalculator {
     }
 
     // Subtract 0.2 if alliance didn't push their barrier (assuming 1 barrier per alliance)
-    if (barriersPushed === 0) {
+    if (!allianceBarrierPushed) {
       baseCoeff -= 0.2;
     }
 
@@ -94,7 +95,8 @@ export class FanrocScoringCalculator {
   static calculateTotalScore(
     whiteBallsScored: number = 0,
     goldenBallsScored: number = 0,
-    barriersPushed: number = 0,
+    allianceBarrierPushed: boolean = false,
+    opponentBarrierPushed: boolean = false,
     imbalanceCategory: number = 2,
     partialParking: number = 0,
     fullParking: number = 0,
@@ -108,7 +110,7 @@ export class FanrocScoringCalculator {
     }
 
     const biologicalPoints = this.calculateBiologicalPoints(goldenBallsScored, whiteBallsScored);
-    const barrierPoints = barriersPushed * 10;
+    const barrierPoints = (allianceBarrierPushed ? 10 : 0) + (opponentBarrierPushed ? 10 : 0);
 
     // End game points
     let endGamePoints = (partialParking * 5) + (fullParking * 10);
@@ -119,7 +121,7 @@ export class FanrocScoringCalculator {
     }
 
     // Adjusted balancing coefficient
-    const coeff = this.getBalancingCoefficient(imbalanceCategory, barriersPushed);
+    const coeff = this.getBalancingCoefficient(imbalanceCategory, allianceBarrierPushed);
 
     // Calculate base score
     const baseScore = (biologicalPoints + barrierPoints) * coeff;
@@ -137,7 +139,8 @@ export class FanrocScoringCalculator {
   static isFanrocScore(score: Score): boolean {
     return score.whiteBallsScored !== undefined ||
            score.goldenBallsScored !== undefined ||
-           score.barriersPushed !== undefined ||
+           score.allianceBarrierPushed !== undefined ||
+           score.opponentBarrierPushed !== undefined ||
            score.imbalanceCategory !== undefined ||
            score.partialParking !== undefined ||
            score.fullParking !== undefined ||

--- a/webui/src/app/core/services/match.service.ts
+++ b/webui/src/app/core/services/match.service.ts
@@ -166,7 +166,8 @@ export class MockMatchService extends MatchService {
             rawScoreData: JSON.stringify({
               whiteBallsScored: 5,
               goldenBallsScored: 5,
-              barriersPushed: true,
+              allianceBarrierPushed: true,
+              opponentBarrierPushed: false,
               imbalanceCategory: 0,
               partialParking: 1,
               fullParking: 2,
@@ -182,7 +183,8 @@ export class MockMatchService extends MatchService {
             rawScoreData: JSON.stringify({
               whiteBallsScored: 3,
               goldenBallsScored: 2,
-              barriersPushed: false,
+              allianceBarrierPushed: false,
+              opponentBarrierPushed: true,
               imbalanceCategory: 1,
               partialParking: 1,
               fullParking: 1,
@@ -240,7 +242,8 @@ export class MockMatchService extends MatchService {
         rawScoreData: JSON.stringify({
           whiteBallsScored: RandomUtils.generateRandomNumber(0, 15),
           goldenBallsScored: RandomUtils.generateRandomNumber(0, 15),
-          barriersPushed: RandomUtils.generateRandomNumber(0, 1) === 1,
+          allianceBarrierPushed: RandomUtils.generateRandomNumber(0, 1) === 1,
+          opponentBarrierPushed: RandomUtils.generateRandomNumber(0, 1) === 1,
           imbalanceCategory: RandomUtils.generateRandomNumber(0, 2),
           partialParking: RandomUtils.generateRandomNumber(0, 2),
           fullParking: RandomUtils.generateRandomNumber(0, 2),

--- a/webui/src/app/features/match-results/components/scoresheet/alliance-scoresheet/alliance-scoresheet.component.ts
+++ b/webui/src/app/features/match-results/components/scoresheet/alliance-scoresheet/alliance-scoresheet.component.ts
@@ -54,7 +54,8 @@ import { RefereeService } from '../../../../../core/services/referee.service';
                       <ng-container [ngSwitch]="field.key">
                         <ng-container *ngSwitchCase="'whiteBallsScored'">⚪</ng-container>
                         <ng-container *ngSwitchCase="'goldenBallsScored'">🟡</ng-container>
-                        <ng-container *ngSwitchCase="'barriersPushed'">🚧</ng-container>
+                        <ng-container *ngSwitchCase="'allianceBarrierPushed'">🚧</ng-container>
+                        <ng-container *ngSwitchCase="'opponentBarrierPushed'">🎯</ng-container>
                         <ng-container *ngSwitchCase="'partialParking'">📍</ng-container>
                         <ng-container *ngSwitchCase="'fullParking'">🏁</ng-container>
                         <ng-container *ngSwitchCase="'imbalanceCategory'">⚖️</ng-container>
@@ -89,7 +90,10 @@ import { RefereeService } from '../../../../../core/services/referee.service';
                     <span class="counter-total" *ngIf="field.key.includes('Parking') && (getValue(scoreData, field.key) || 0) > 0">
                       {{ (getValue(scoreData, field.key) || 0) * 5 }}
                     </span>
-                    <span class="counter-total" *ngIf="field.key === 'barriersPushed' && (getValue(scoreData, field.key) || 0) > 0">
+                    <span class="counter-total" *ngIf="field.key === 'allianceBarrierPushed' && (getValue(scoreData, field.key) || 0) > 0">
+                      {{ (getValue(scoreData, field.key) || 0) * 10 }}
+                    </span>
+                    <span class="counter-total" *ngIf="field.key === 'opponentBarrierPushed' && (getValue(scoreData, field.key) || 0) > 0">
                       {{ (getValue(scoreData, field.key) || 0) * 10 }}
                     </span>
                   </div>
@@ -99,8 +103,8 @@ import { RefereeService } from '../../../../../core/services/referee.service';
                     <i class="bi bi-plus-lg"></i>
                   </button>
                 </div>
-                <!-- Toggle button for boolean fields (barriersPushed, redCard) -->
-                <div class="toggle-controls" *ngIf="editable && field.type === 'boolean'">
+                <!-- Toggle button for boolean fields (allianceBarrierPushed, opponentBarrierPushed, redCard) -->
+                <div [ngClass]="{'bg-danger': (field.key === 'allianceBarrierPushed' && alliance === 'red') || (field.key === 'opponentBarrierPushed' && alliance === 'blue'), 'bg-primary': (field.key === 'allianceBarrierPushed' && alliance === 'blue') || (field.key === 'opponentBarrierPushed' && alliance === 'red')}" class="toggle-controls rounded-3 p-3" *ngIf="editable && field.type === 'boolean'">
                   <button (click)="toggleBooleanValue(field.key)"
                           [class.active]="getValue(scoreData, field.key)"
                           class="btn btn-lg boolean-toggle-button">
@@ -126,7 +130,10 @@ import { RefereeService } from '../../../../../core/services/referee.service';
                     <span class="counter-total" *ngIf="field.key.includes('Parking') && (getValue(scoreData, field.key) || 0) > 0">
                       {{ (getValue(scoreData, field.key) || 0) * 5 }}
                     </span>
-                    <span class="counter-total" *ngIf="field.key === 'barriersPushed' && (getValue(scoreData, field.key) || 0) > 0">
+                    <span class="counter-total" *ngIf="field.key === 'allianceBarrierPushed' && (getValue(scoreData, field.key) || 0) > 0">
+                      {{ (getValue(scoreData, field.key) || 0) * 10 }}
+                    </span>
+                    <span class="counter-total" *ngIf="field.key === 'opponentBarrierPushed' && (getValue(scoreData, field.key) || 0) > 0">
                       {{ (getValue(scoreData, field.key) || 0) * 10 }}
                     </span>
                   </div>

--- a/webui/src/app/features/match-results/components/scoresheet/scoresheet.config.ts
+++ b/webui/src/app/features/match-results/components/scoresheet/scoresheet.config.ts
@@ -52,7 +52,8 @@ export const CUSTOM_SEASON_CONFIG: ScoresheetConfig = {
                     title: 'Barriers & Movement',
                     type: 'fields',
                     fields: [
-                        { key: 'barriersPushed', label: 'Barrier Pushed Away', type: 'boolean' }
+                        { key: 'allianceBarrierPushed', label: 'Alliance Barrier Pushed', type: 'boolean' },
+                        { key: 'opponentBarrierPushed', label: 'Opponent Barrier Pushed', type: 'boolean' }
                     ]
                 },
                 {

--- a/webui/src/app/features/referee/score-tracking/score-tracking.html
+++ b/webui/src/app/features/referee/score-tracking/score-tracking.html
@@ -101,27 +101,44 @@
             <i class="bi bi-barrier me-2"></i>Barriers & Movement
           </div>
 
-          <!-- Barrier Push Toggle Button -->
+          <!-- Alliance Barrier Push Toggle Button -->
           <div class="barrier-push-section">
-            <div class="d-flex justify-content-center mt-3">
-              <button (click)="toggleBarrierPush()"
-                      [class.active]="barriersPushed()"
+            <div [class.bg-danger]="color === 'red'" [class.bg-primary]="color === 'blue'" class="d-flex justify-content-center mt-3 rounded-3 p-3">
+              <button (click)="toggleAllianceBarrierPush()"
+                      [class.active]="allianceBarrierPushed()"
+                      [class.btn-danger]="color === 'red'"
+                      [class.btn-primary]="color === 'blue'"
                       [disabled]="submitting()"
                       class="btn btn-lg barrier-push-button">
                 <div class="barrier-push-content">
                   <div class="barrier-push-icon-large">🚧</div>
                   <div class="barrier-push-text">
-                    <div class="barrier-push-title">{{ barriersPushed() ? 'Barrier Pushed' : 'Push Barrier' }}</div>
-                    <div class="barrier-push-subtitle">+10 points if pushed, -0.2 balance if not</div>
+                    <div class="barrier-push-title">{{ allianceBarrierPushed() ? 'Alliance Barrier Pushed' : 'Push Alliance Barrier' }}</div>
+                    <div class="barrier-push-subtitle">+10 points, no -0.2 penalty</div>
                   </div>
                 </div>
               </button>
             </div>
-            @if (!barriersPushed()) {
-              <div class="alert alert-warning mt-3 text-center small">
-                ⚠️ No barrier pushed - 0.2 penalty will be applied to balance coefficient
-              </div>
-            }
+          </div>
+
+          <!-- Opponent Barrier Push Toggle Button -->
+          <div class="barrier-push-section">
+            <div [class.bg-primary]="color === 'red'" [class.bg-danger]="color === 'blue'" class="d-flex justify-content-center mt-3 rounded-3 p-3">
+              <button (click)="toggleOpponentBarrierPush()"
+                      [class.active]="opponentBarrierPushed()"
+                      [class.btn-primary]="color === 'red'"
+                      [class.btn-danger]="color === 'blue'"
+                      [disabled]="submitting()"
+                      class="btn btn-lg barrier-push-button">
+                <div class="barrier-push-content">
+                  <div class="barrier-push-icon-large">🎯</div>
+                  <div class="barrier-push-text">
+                    <div class="barrier-push-title">{{ opponentBarrierPushed() ? 'Opponent Barrier Pushed' : 'Push Opponent Barrier' }}</div>
+                    <div class="barrier-push-subtitle">+10 bonus points</div>
+                  </div>
+                </div>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/webui/src/app/features/referee/score-tracking/score-tracking.ts
+++ b/webui/src/app/features/referee/score-tracking/score-tracking.ts
@@ -50,7 +50,7 @@ export class ScoreTracking implements OnInit, OnDestroy {
   private version: WritableSignal<number> = signal(0);
   private readonly sourceId: string = this.initSourceId();
 
-  // Fanroc scoring counters (barriersPushed moved to separate boolean signal)
+  // Fanroc scoring counters (barriersPushed moved to separate boolean signals)
   counters: Record<CounterKey, WritableSignal<number>> = {
     whiteBallsScored: signal(0),
     goldenBallsScored: signal(0),
@@ -61,7 +61,8 @@ export class ScoreTracking implements OnInit, OnDestroy {
   };
 
   // Barrier push as boolean (toggle like red card)
-  barriersPushed: WritableSignal<boolean> = signal(false);
+  allianceBarrierPushed: WritableSignal<boolean> = signal(false);
+  opponentBarrierPushed: WritableSignal<boolean> = signal(false);
 
   // Red card flag
   redCard: WritableSignal<boolean> = signal(false);
@@ -141,8 +142,13 @@ export class ScoreTracking implements OnInit, OnDestroy {
     this.onScoreUpdate('reset', 'whiteBallsScored', this.counters.whiteBallsScored()); // Trigger update
   }
 
-  toggleBarrierPush() {
-    this.barriersPushed.set(!this.barriersPushed());
+  toggleAllianceBarrierPush() {
+    this.allianceBarrierPushed.set(!this.allianceBarrierPushed());
+    this.onScoreUpdate('reset', 'whiteBallsScored', this.counters.whiteBallsScored()); // Trigger update
+  }
+
+  toggleOpponentBarrierPush() {
+    this.opponentBarrierPushed.set(!this.opponentBarrierPushed());
     this.onScoreUpdate('reset', 'whiteBallsScored', this.counters.whiteBallsScored()); // Trigger update
   }
 
@@ -159,7 +165,8 @@ export class ScoreTracking implements OnInit, OnDestroy {
     });
     this.selectedImbalance.set(2); // Reset to default
     this.redCard.set(false);
-    this.barriersPushed.set(false);
+    this.allianceBarrierPushed.set(false);
+    this.opponentBarrierPushed.set(false);
   }
 
   canDecrease(key: CounterKey): boolean {
@@ -272,7 +279,8 @@ export class ScoreTracking implements OnInit, OnDestroy {
         state: {
           whiteBallsScored: this.counters.whiteBallsScored(),
           goldenBallsScored: this.counters.goldenBallsScored(),
-          barriersPushed: this.barriersPushed() ? 1 : 0,
+          allianceBarrierPushed: this.allianceBarrierPushed(),
+          opponentBarrierPushed: this.opponentBarrierPushed(),
           partialParking: this.counters.partialParking(),
           fullParking: this.counters.fullParking(),
           imbalanceCategory: this.selectedImbalance(),
@@ -289,7 +297,8 @@ export class ScoreTracking implements OnInit, OnDestroy {
     return {
       whiteBallsScored: this.counters.whiteBallsScored(),
       goldenBallsScored: this.counters.goldenBallsScored(),
-      barriersPushed: this.barriersPushed() ? 1 : 0,
+      allianceBarrierPushed: this.allianceBarrierPushed(),
+      opponentBarrierPushed: this.opponentBarrierPushed(),
       partialParking: this.counters.partialParking(),
       fullParking: this.counters.fullParking(),
       imbalanceCategory: this.selectedImbalance(),


### PR DESCRIPTION
- Replace barriersPushed (integer) with allianceBarrierPushed and opponentBarrierPushed (boolean)
- allianceBarrierPushed affects both points (+10) and coefficient penalty (-0.2 if not pushed)
- opponentBarrierPushed only adds bonus points (+10)
- Update Java backend, TypeScript models, and Angular UI components